### PR TITLE
docs/spec: add common IO schema + vocabulary map + validator + CI

### DIFF
--- a/.github/workflows/schema-ci.yml
+++ b/.github/workflows/schema-ci.yml
@@ -1,0 +1,23 @@
+name: IO Schema Validation
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps
+        run: pip install jsonschema
+      - name: Validate samples
+        run: |
+          python scripts/validate_io.py --schema common/schema/brain.signal.json --file samples/brain_signals.ndjson
+          python scripts/validate_io.py --schema common/schema/oracle.trade_event.json --file samples/trade_events.ndjson
+          python scripts/validate_io.py --schema common/schema/oracle.strategy_return.json --file samples/strategy_returns.ndjson
+          python scripts/validate_io.py --schema common/schema/portfolio.allocation.json --file samples/portfolio_allocation.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: validate-io
+validate-io:
+	python scripts/validate_io.py --schema common/schema/brain.signal.json --file samples/brain_signals.ndjson
+	python scripts/validate_io.py --schema common/schema/oracle.trade_event.json --file samples/trade_events.ndjson
+	python scripts/validate_io.py --schema common/schema/oracle.strategy_return.json --file samples/strategy_returns.ndjson
+	python scripts/validate_io.py --schema common/schema/portfolio.allocation.json --file samples/portfolio_allocation.json

--- a/README.md
+++ b/README.md
@@ -104,3 +104,44 @@ Released under the [MIT License](LICENSE).
 
 ## 🧿 A Final Whisper
 > "The market murmurs through entropy, and EchoWeaver replies with memory and myth."
+
+## Common IO & Validation
+
+This repo ships a shared **Vocabulary Map** and **JSON Schemas** for cross-repo interoperability:
+
+- Brain → Oracle: `common/schema/brain.signal.json`
+- Oracle logs: `common/schema/oracle.trade_event.json`
+- Oracle summary (to Portfolio): `common/schema/oracle.strategy_return.json`
+- Portfolio allocations: `common/schema/portfolio.allocation.json`
+- Shared defs: `common/schema/defs.json`
+
+**Validate locally**
+```bash
+make validate-io
+# or
+python scripts/validate_io.py --schema common/schema/brain.signal.json --file samples/brain_signals.ndjson
+```
+
+**CI**
+A workflow validates the samples on every PR to prevent schema drift.
+
+---
+
+## 5) How to wire in each repo (quick notes)
+
+- **Brain**: emit Signals conforming to `brain.signal.json` (write to NDJSON).
+- **TradeOracle**:
+  - read Signals → execute,
+  - emit `trade_events.ndjson` (TradeEvent),
+  - emit `strategy_returns.ndjson` (StrategyReturn).
+- **Entropy-Portfolio-Lab**: read `strategy_returns.ndjson` across symbols/strategies → produce `portfolio_allocation.json`.
+
+---
+
+Want me to also:
+- add a **Python loader** (`common/io_loader.py`) that auto-validates on read/write,
+- or patch your **data pipes** in EchoWeaver/Entropy-Portfolio-Lab to write/read these exact formats?
+
+If yes, tell me which repo(s) first and I’ll drop the glue functions + unit tests right away.
+
+—

--- a/common/schema/brain.signal.json
+++ b/common/schema/brain.signal.json
@@ -1,0 +1,21 @@
+{
+  "$id": "https://spec.local/brain/signal.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "https://spec.local/common/defs.json",
+  "title": "Signal",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": { "$ref": "https://spec.local/common/defs.json#/$defs/id" },
+    "timestamp": { "$ref": "https://spec.local/common/defs.json#/$defs/isoTimestamp" },
+    "symbol": { "$ref": "https://spec.local/common/defs.json#/$defs/symbol" },
+    "side": { "$ref": "https://spec.local/common/defs.json#/$defs/side" },
+    "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+    "entropy_score": { "type": "number", "minimum": 0, "maximum": 1 },
+    "regime_state": { "$ref": "https://spec.local/common/defs.json#/$defs/regimeState" },
+    "features": { "type": "object", "additionalProperties": { "type": ["number", "string", "boolean"] } },
+    "hash": { "$ref": "https://spec.local/common/defs.json#/$defs/hash" },
+    "capsule_id": { "type": "string" }
+  },
+  "required": ["id", "timestamp", "symbol", "side", "confidence", "entropy_score", "regime_state"]
+}

--- a/common/schema/bundles.signals.json
+++ b/common/schema/bundles.signals.json
@@ -1,0 +1,6 @@
+{
+  "$id": "https://spec.local/brain/signals_bundle.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": { "$ref": "https://spec.local/brain/signal.json" }
+}

--- a/common/schema/defs.json
+++ b/common/schema/defs.json
@@ -1,0 +1,15 @@
+{
+  "$id": "https://spec.local/common/defs.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "isoTimestamp": { "type": "string", "format": "date-time" },
+    "symbol": { "type": "string", "minLength": 1, "maxLength": 50 },
+    "id": { "type": "string", "minLength": 1, "maxLength": 120 },
+    "hash": { "type": "string", "pattern": "^(sha256|blake3):[A-Fa-f0-9]{64}$" },
+    "regimeState": {
+      "type": "string",
+      "enum": ["flat", "trend_up", "trend_down", "volatile", "collapsing", "recovering"]
+    },
+    "side": { "type": "string", "enum": ["LONG", "SHORT", "FLAT"] }
+  }
+}

--- a/common/schema/oracle.strategy_return.json
+++ b/common/schema/oracle.strategy_return.json
@@ -1,0 +1,20 @@
+{
+  "$id": "https://spec.local/oracle/strategy_return.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "https://spec.local/common/defs.json",
+  "title": "StrategyReturn",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": { "$ref": "https://spec.local/common/defs.json#/$defs/id" },
+    "timestamp": { "$ref": "https://spec.local/common/defs.json#/$defs/isoTimestamp" },
+    "strategy": { "type": "string" },
+    "symbol": { "$ref": "https://spec.local/common/defs.json#/$defs/symbol" },
+    "pnl": { "type": "number" },
+    "equity": { "type": "number" },
+    "drawdown": { "type": "number", "minimum": 0 },
+    "sharpe": { "type": "number" },
+    "regime_state": { "$ref": "https://spec.local/common/defs.json#/$defs/regimeState" }
+  },
+  "required": ["id", "timestamp", "strategy", "symbol", "pnl", "equity"]
+}

--- a/common/schema/oracle.trade_event.json
+++ b/common/schema/oracle.trade_event.json
@@ -1,0 +1,25 @@
+{
+  "$id": "https://spec.local/oracle/trade_event.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "https://spec.local/common/defs.json",
+  "title": "TradeEvent",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": { "$ref": "https://spec.local/common/defs.json#/$defs/id" },
+    "timestamp": { "$ref": "https://spec.local/common/defs.json#/$defs/isoTimestamp" },
+    "symbol": { "$ref": "https://spec.local/common/defs.json#/$defs/symbol" },
+    "event": { "type": "string", "enum": ["ENTER", "SCALE_IN", "EXIT", "STOP", "TAKE_PROFIT", "REVERSE"] },
+    "side": { "$ref": "https://spec.local/common/defs.json#/$defs/side" },
+    "qty": { "type": "number" },
+    "price": { "type": "number" },
+    "regime_state": { "$ref": "https://spec.local/common/defs.json#/$defs/regimeState" },
+    "entropy_score": { "type": "number", "minimum": 0, "maximum": 1 },
+    "pnl": { "type": "number" },
+    "trade_id": { "type": "string" },
+    "signal_id": { "type": "string" },
+    "hash": { "$ref": "https://spec.local/common/defs.json#/$defs/hash" },
+    "meta": { "type": "object", "additionalProperties": true }
+  },
+  "required": ["id", "timestamp", "symbol", "event", "side", "qty", "price"]
+}

--- a/common/schema/portfolio.allocation.json
+++ b/common/schema/portfolio.allocation.json
@@ -1,0 +1,32 @@
+{
+  "$id": "https://spec.local/portfolio/allocation.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "https://spec.local/common/defs.json",
+  "title": "PortfolioAllocation",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": { "$ref": "https://spec.local/common/defs.json#/$defs/id" },
+    "timestamp": { "$ref": "https://spec.local/common/defs.json#/$defs/isoTimestamp" },
+    "allocations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "strategy": { "type": "string" },
+          "symbol": { "$ref": "https://spec.local/common/defs.json#/$defs/symbol" },
+          "weight": { "type": "number", "minimum": 0, "maximum": 1 },
+          "entropy_risk": { "type": "number", "minimum": 0, "maximum": 1 }
+        },
+        "required": ["strategy", "symbol", "weight"]
+      }
+    },
+    "constraints": {
+      "type": "object",
+      "additionalProperties": { "type": ["number", "string", "boolean"] }
+    },
+    "hash": { "$ref": "https://spec.local/common/defs.json#/$defs/hash" }
+  },
+  "required": ["id", "timestamp", "allocations"]
+}

--- a/common/vocabulary.md
+++ b/common/vocabulary.md
@@ -1,0 +1,20 @@
+# Vocabulary Map (Brain ⇌ TradeOracle ⇌ Entropy-Portfolio)
+
+| Concept / Field       | Brain (signals / capsules) | TradeOracle (strategy / execution) | Entropy-Portfolio-Lab (allocation / risk) | **Preferred** |
+|---|---|---|---|---|
+| Uncertainty / Risk    | confidence, entropy_score  | entropy_gate, regime_entropy        | entropy_risk, entropy_metric               | **entropy_score** (0–1) |
+| State / Mode          | capsule_state, claim_status| regime_state, motif_flag            | portfolio_state                             | **regime_state** (enum) |
+| Signal Strength       | activation, confidence     | conviction, motif_strength          | —                                          | **confidence** (0–1) |
+| Structural Unit       | capsule, statement, note   | motif, glyph, trade_rule            | portfolio_block, weight_vector              | **capsule** (research), **motif** (trading) |
+| Event                 | signal_timestamp           | trade_event, execution_time         | rebalance_time                              | **timestamp** (ISO-8601) |
+| Output                | capsule.json               | trade_log.csv                       | weights.csv                                  | **Unified I/O** (JSON/CSV + hash) |
+| Performance Metric    | —                          | pnl_curve, ROI_scorer, drawdown     | entropy_diversification, expected_return     | **pnl_curve, drawdown, sharpe** |
+| Capital Unit          | —                          | position_size, risk_unit            | weight, allocation                           | **weight** (0–1) |
+| Check / Guard         | assumptions, proof_guard   | risk_gate, entropy_gate             | constraint, bound                            | **constraint** (general), **risk_gate** (execution) |
+| Provenance            | hash, capsule_id           | trade_id, hash_chain                | portfolio_id                                 | **id + hash** (chainable) |
+
+**Notes**
+- Use `entropy_score` everywhere for uncertainty/risk (0–1).
+- Use `regime_state` for modes (e.g., `flat`, `trend_up`, `trend_down`, `volatile`, `collapsing`, `recovering`).
+- Standardize `timestamp` as ISO-8601 UTC (`Z`).
+- Normalize all portfolio capital fields as `weight` in `[0,1]` (sum to 1.0).

--- a/samples/brain_signals.ndjson
+++ b/samples/brain_signals.ndjson
@@ -1,0 +1,2 @@
+{"id":"sig-2025-09-25-NQ-0001","timestamp":"2025-09-25T08:00:03Z","symbol":"NQ","side":"LONG","confidence":0.74,"entropy_score":0.38,"regime_state":"trend_up","features":{"rsi":58.3,"vwap_dev":-0.12}}
+{"id":"sig-2025-09-25-CL-0007","timestamp":"2025-09-25T08:02:10Z","symbol":"CL","side":"SHORT","confidence":0.52,"entropy_score":0.61,"regime_state":"volatile"}

--- a/samples/portfolio_allocation.json
+++ b/samples/portfolio_allocation.json
@@ -1,0 +1,10 @@
+{
+  "id": "alloc-2025-09-25-v1",
+  "timestamp": "2025-09-25T21:05:00Z",
+  "allocations": [
+    { "strategy": "SigmaBloom", "symbol": "CL", "weight": 0.45, "entropy_risk": 0.32 },
+    { "strategy": "EchoWeaver", "symbol": "NQ", "weight": 0.35, "entropy_risk": 0.41 },
+    { "strategy": "GammaLite", "symbol": "ES", "weight": 0.20, "entropy_risk": 0.28 }
+  ],
+  "constraints": { "max_symbol_weight": 0.5 }
+}

--- a/samples/strategy_returns.ndjson
+++ b/samples/strategy_returns.ndjson
@@ -1,0 +1,2 @@
+{"id":"ret-2025-09-25-CL-SigmaBloom","timestamp":"2025-09-25T21:00:00Z","strategy":"SigmaBloom","symbol":"CL","pnl":1250.0,"equity":101250.0,"drawdown":0.012,"sharpe":1.8,"regime_state":"trend_up"}
+{"id":"ret-2025-09-25-NQ-EchoWeaver","timestamp":"2025-09-25T21:00:00Z","strategy":"EchoWeaver","symbol":"NQ","pnl":-350.0,"equity":99850.0,"drawdown":0.018,"sharpe":1.2,"regime_state":"volatile"}

--- a/samples/trade_events.ndjson
+++ b/samples/trade_events.ndjson
@@ -1,0 +1,2 @@
+{"id":"evt-2025-09-25-001","timestamp":"2025-09-25T08:01:10Z","symbol":"CL","event":"ENTER","side":"LONG","qty":2,"price":80.14,"regime_state":"trend_up","entropy_score":0.41,"trade_id":"trade-CL-2025-0925-A","signal_id":"sig-2025-09-25-CL-0007"}
+{"id":"evt-2025-09-25-002","timestamp":"2025-09-25T08:09:40Z","symbol":"CL","event":"TAKE_PROFIT","side":"LONG","qty":1,"price":80.98}

--- a/scripts/validate_io.py
+++ b/scripts/validate_io.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Validate JSON or NDJSON against schemas in common/schema/.
+Usage:
+  python scripts/validate_io.py --schema common/schema/brain.signal.json --file samples/brain_signals.ndjson
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+from typing import Iterable, Tuple
+from urllib.parse import urlparse
+
+from jsonschema import Draft202012Validator, RefResolver
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+
+
+def load_json(path: pathlib.Path) -> object:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def candidate_paths(schema_dir: pathlib.Path, rel_path: pathlib.Path) -> Iterable[pathlib.Path]:
+    yield schema_dir / rel_path
+    yield schema_dir / rel_path.name
+    yield REPO_ROOT / rel_path
+    yield REPO_ROOT / "common" / rel_path.name
+    yield REPO_ROOT / "common" / "schema" / rel_path.name
+
+
+def validator_for(schema_path: str) -> Draft202012Validator:
+    schema_file = pathlib.Path(schema_path).resolve()
+    schema_dir = schema_file.parent
+    schema = load_json(schema_file)
+
+    def resolve(uri: str):
+        parsed = urlparse(uri)
+        if parsed.scheme == "https" and parsed.netloc == "spec.local":
+            rel = pathlib.Path(parsed.path.lstrip("/"))
+            seen: set[str] = set()
+            for candidate in candidate_paths(schema_dir, rel):
+                key = str(candidate)
+                if key in seen:
+                    continue
+                seen.add(key)
+                if candidate.exists():
+                    return load_json(candidate)
+        return None
+
+    class LocalResolver(RefResolver):
+        def resolve_remote(self, uri: str):  # type: ignore[override]
+            document = resolve(uri)
+            if document is not None:
+                return document
+            return super().resolve_remote(uri)
+
+    return Draft202012Validator(schema, resolver=LocalResolver.from_schema(schema))
+
+
+def iter_ndjson(file_path: pathlib.Path) -> Iterable[Tuple[int, object]]:
+    with file_path.open("r", encoding="utf-8") as handle:
+        for index, raw in enumerate(handle, 1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                yield index, json.loads(line)
+            except json.JSONDecodeError as exc:  # pragma: no cover - explicit failure path
+                raise SystemExit(f"Line {index}: invalid JSON: {exc}") from exc
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--schema", required=True)
+    parser.add_argument("--file", required=True)
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    validator = validator_for(args.schema)
+    target_path = pathlib.Path(args.file)
+
+    try:
+        if target_path.suffix == ".ndjson":
+            success = True
+            for index, payload in iter_ndjson(target_path):
+                errors = sorted(validator.iter_errors(payload), key=lambda err: err.path)
+                if errors:
+                    success = False
+                    print(f"❌ Line {index} failed:")
+                    for error in errors:
+                        location = ".".join(str(part) for part in error.path)
+                        prefix = f"{location}: " if location else ""
+                        print(f"   - {prefix}{error.message}")
+            if not success:
+                return 1
+            print("✅ NDJSON validated.")
+        else:
+            payload = load_json(target_path.resolve())
+            validator.validate(payload)
+            print("✅ JSON validated.")
+    except Exception as exc:  # pragma: no cover - CLI surface
+        raise SystemExit(str(exc)) from exc
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a shared vocabulary map and JSON Schemas that describe signal, execution, and portfolio payloads
- provide reference samples, a validation helper script, and a Makefile target for local schema checks
- document the workflow in the README and wire CI to validate sample data against the schemas

## Testing
- make validate-io

------
https://chatgpt.com/codex/tasks/task_e_68d5dca75a648320a9557e0742c98e1d