### PR TITLE
io(common): add schema-aware loader, NDJSON utilities, hashing, pandas adapters, CLI + tests/CI

### DIFF
--- a/.github/workflows/schema-ci.yml
+++ b/.github/workflows/schema-ci.yml
@@ -14,10 +14,12 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install deps
-        run: pip install jsonschema
-      - name: Validate samples
         run: |
-          python scripts/validate_io.py --schema common/schema/brain.signal.json --file samples/brain_signals.ndjson
-          python scripts/validate_io.py --schema common/schema/oracle.trade_event.json --file samples/trade_events.ndjson
-          python scripts/validate_io.py --schema common/schema/oracle.strategy_return.json --file samples/strategy_returns.ndjson
-          python scripts/validate_io.py --schema common/schema/portfolio.allocation.json --file samples/portfolio_allocation.json
+          pip install -r requirements.txt
+      - name: Validate samples via loader + CLI
+        run: |
+          make io-validate
+          python scripts/io_cli.py summarize --kind returns --path samples/strategy_returns.ndjson
+      - name: Unit tests
+        run: |
+          make test

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,17 @@ validate-io:
 	python scripts/validate_io.py --schema common/schema/oracle.trade_event.json --file samples/trade_events.ndjson
 	python scripts/validate_io.py --schema common/schema/oracle.strategy_return.json --file samples/strategy_returns.ndjson
 	python scripts/validate_io.py --schema common/schema/portfolio.allocation.json --file samples/portfolio_allocation.json
+
+.PHONY: io-validate io-summarize test
+io-validate:
+	python scripts/io_cli.py validate --kind signals --path samples/brain_signals.ndjson
+	python scripts/io_cli.py validate --kind events  --path samples/trade_events.ndjson
+	python scripts/io_cli.py validate --kind returns --path samples/strategy_returns.ndjson
+	python scripts/io_cli.py validate --kind alloc   --path samples/portfolio_allocation.json
+
+io-summarize:
+	python scripts/io_cli.py summarize --kind returns --path samples/strategy_returns.ndjson
+	python scripts/io_cli.py summarize --kind events  --path samples/trade_events.ndjson
+
+test:
+	pytest -q

--- a/common/io_loader.py
+++ b/common/io_loader.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import typing as t
+from dataclasses import asdict, dataclass, field
+
+from jsonschema import Draft202012Validator, RefResolver
+
+from .io_utils import canonical_hash, json_read, json_write, ndjson_iter, ndjson_write, prune_nones
+
+SCHEMA_BASE = pathlib.Path(__file__).resolve().parent / "schema"
+LOCAL_ID_PREFIX = "https://spec.local/"
+
+
+def _load_schema(rel: str) -> dict:
+    path = (SCHEMA_BASE / rel).resolve()
+    if not path.exists():
+        path = (SCHEMA_BASE / pathlib.Path(rel).name).resolve()
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _to_payload(instance: t.Any) -> dict:
+    return prune_nones(asdict(instance))
+
+
+def _validator(schema_rel: str) -> Draft202012Validator:
+    schema = _load_schema(schema_rel)
+
+    class LocalResolver(RefResolver):
+        def resolve_remote(self, uri: str):  # type: ignore[override]
+            if uri.startswith(LOCAL_ID_PREFIX):
+                rel = uri.replace(LOCAL_ID_PREFIX, "")
+                return _load_schema(rel)
+            return super().resolve_remote(uri)
+
+    return Draft202012Validator(schema, resolver=LocalResolver.from_schema(schema))
+
+
+@dataclass
+class Signal:
+    id: str
+    timestamp: str
+    symbol: str
+    side: str
+    confidence: float
+    entropy_score: float
+    regime_state: str
+    features: t.Dict[str, t.Any] = field(default_factory=dict)
+    hash: t.Optional[str] = None
+    capsule_id: t.Optional[str] = None
+
+    SCHEMA = "brain.signal.json"
+
+    def validate(self) -> None:
+        _validator(self.SCHEMA).validate(_to_payload(self))
+
+    def with_hash(self, algo: str = "sha256") -> "Signal":
+        payload = _to_payload(self)
+        payload.pop("hash", None)
+        self.hash = canonical_hash(payload, algo)
+        return self
+
+
+@dataclass
+class TradeEvent:
+    id: str
+    timestamp: str
+    symbol: str
+    event: str
+    side: str
+    qty: float
+    price: float
+    regime_state: t.Optional[str] = None
+    entropy_score: t.Optional[float] = None
+    pnl: t.Optional[float] = None
+    trade_id: t.Optional[str] = None
+    signal_id: t.Optional[str] = None
+    hash: t.Optional[str] = None
+    meta: t.Dict[str, t.Any] = field(default_factory=dict)
+
+    SCHEMA = "oracle.trade_event.json"
+
+    def validate(self) -> None:
+        _validator(self.SCHEMA).validate(_to_payload(self))
+
+    def with_hash(self, algo: str = "sha256") -> "TradeEvent":
+        payload = _to_payload(self)
+        payload.pop("hash", None)
+        self.hash = canonical_hash(payload, algo)
+        return self
+
+
+@dataclass
+class StrategyReturn:
+    id: str
+    timestamp: str
+    strategy: str
+    symbol: str
+    pnl: float
+    equity: float
+    drawdown: t.Optional[float] = None
+    sharpe: t.Optional[float] = None
+    regime_state: t.Optional[str] = None
+
+    SCHEMA = "oracle.strategy_return.json"
+
+    def validate(self) -> None:
+        _validator(self.SCHEMA).validate(_to_payload(self))
+
+
+@dataclass
+class AllocationItem:
+    strategy: str
+    symbol: str
+    weight: float
+    entropy_risk: t.Optional[float] = None
+
+
+@dataclass
+class PortfolioAllocation:
+    id: str
+    timestamp: str
+    allocations: t.List[AllocationItem]
+    constraints: t.Dict[str, t.Any] = field(default_factory=dict)
+    hash: t.Optional[str] = None
+
+    SCHEMA = "portfolio.allocation.json"
+
+    def validate(self) -> None:
+        data = _to_payload(self)
+        _validator(self.SCHEMA).validate(data)
+        total = sum(item["weight"] for item in data["allocations"])
+        if abs(total - 1.0) > 1e-6:
+            raise ValueError(f"allocations weights must sum to 1.0 (got {total:.8f})")
+
+    def with_hash(self, algo: str = "sha256") -> "PortfolioAllocation":
+        payload = _to_payload(self)
+        payload.pop("hash", None)
+        self.hash = canonical_hash(payload, algo)
+        return self
+
+
+def read_signals_ndjson(path: t.Union[str, pathlib.Path]) -> t.List[Signal]:
+    out: t.List[Signal] = []
+    for obj in ndjson_iter(path):
+        signal = Signal(**obj)
+        signal.validate()
+        out.append(signal)
+    return out
+
+
+def write_signals_ndjson(
+    path: t.Union[str, pathlib.Path], signals: t.Iterable[Signal], add_hash: bool = True
+) -> None:
+    rows = []
+    for signal in signals:
+        if add_hash and not signal.hash:
+            signal.with_hash()
+        signal.validate()
+        rows.append(_to_payload(signal))
+    ndjson_write(path, rows)
+
+
+def read_trade_events_ndjson(path: t.Union[str, pathlib.Path]) -> t.List[TradeEvent]:
+    out: t.List[TradeEvent] = []
+    for obj in ndjson_iter(path):
+        event = TradeEvent(**obj)
+        event.validate()
+        out.append(event)
+    return out
+
+
+def write_trade_events_ndjson(
+    path: t.Union[str, pathlib.Path], events: t.Iterable[TradeEvent], add_hash: bool = True
+) -> None:
+    rows: t.List[dict] = []
+    for event in events:
+        if add_hash and not event.hash:
+            event.with_hash()
+        event.validate()
+        rows.append(_to_payload(event))
+    ndjson_write(path, rows)
+
+
+def read_strategy_returns_ndjson(path: t.Union[str, pathlib.Path]) -> t.List[StrategyReturn]:
+    out: t.List[StrategyReturn] = []
+    for obj in ndjson_iter(path):
+        record = StrategyReturn(**obj)
+        record.validate()
+        out.append(record)
+    return out
+
+
+def write_strategy_returns_ndjson(
+    path: t.Union[str, pathlib.Path], rows: t.Iterable[StrategyReturn]
+) -> None:
+    payload: t.List[dict] = []
+    for record in rows:
+        record.validate()
+        payload.append(_to_payload(record))
+    ndjson_write(path, payload)
+
+
+def read_allocation_json(path: t.Union[str, pathlib.Path]) -> PortfolioAllocation:
+    obj = json_read(path)
+    allocations = [AllocationItem(**item) for item in obj.get("allocations", [])]
+    allocation = PortfolioAllocation(
+        id=obj["id"],
+        timestamp=obj["timestamp"],
+        allocations=allocations,
+        constraints=obj.get("constraints", {}),
+        hash=obj.get("hash"),
+    )
+    allocation.validate()
+    return allocation
+
+
+def write_allocation_json(
+    path: t.Union[str, pathlib.Path], allocation: PortfolioAllocation, add_hash: bool = True
+) -> None:
+    if add_hash and not allocation.hash:
+        allocation.with_hash()
+    allocation.validate()
+    json_write(path, _to_payload(allocation))

--- a/common/io_pandas.py
+++ b/common/io_pandas.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import List
+
+import pandas as pd
+
+from .io_loader import AllocationItem, PortfolioAllocation, Signal, StrategyReturn, TradeEvent
+
+
+def signals_to_df(rows: List[Signal]) -> pd.DataFrame:
+    return pd.DataFrame([asdict(row) for row in rows])
+
+
+def trade_events_to_df(rows: List[TradeEvent]) -> pd.DataFrame:
+    return pd.DataFrame([asdict(row) for row in rows])
+
+
+def strategy_returns_to_df(rows: List[StrategyReturn]) -> pd.DataFrame:
+    return pd.DataFrame([asdict(row) for row in rows])
+
+
+def allocation_to_df(allocation: PortfolioAllocation) -> pd.DataFrame:
+    return pd.DataFrame([asdict(item) for item in allocation.allocations])

--- a/common/io_utils.py
+++ b/common/io_utils.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+import typing as t
+from dataclasses import asdict
+
+JSONDict = t.Dict[str, t.Any]
+
+
+def ndjson_iter(path: t.Union[str, pathlib.Path]) -> t.Iterable[JSONDict]:
+    p = pathlib.Path(path)
+    with p.open("r", encoding="utf-8") as f:
+        for i, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except Exception as e:  # pragma: no cover - exercised via tests
+                raise ValueError(f"{p}:{i}: invalid JSON - {e}") from e
+
+
+def ndjson_write(path: t.Union[str, pathlib.Path], rows: t.Iterable[JSONDict]) -> None:
+    p = pathlib.Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as f:
+        for obj in rows:
+            f.write(json.dumps(obj, separators=(",", ":"), ensure_ascii=False) + "\n")
+
+
+def json_write(path: t.Union[str, pathlib.Path], obj: JSONDict) -> None:
+    p = pathlib.Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(obj, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def json_read(path: t.Union[str, pathlib.Path]) -> JSONDict:
+    return json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+
+
+def prune_nones(value: t.Any) -> t.Any:
+    if isinstance(value, dict):
+        return {k: prune_nones(v) for k, v in value.items() if v is not None}
+    if isinstance(value, list):
+        return [prune_nones(v) for v in value]
+    return value
+
+
+def canonical_hash(obj: t.Union[JSONDict, t.Any], algo: str = "sha256") -> str:
+    """Stable content hash of dicts/dataclasses using sorted keys and no spaces."""
+    if hasattr(obj, "__dataclass_fields__"):
+        obj = asdict(obj)  # type: ignore[assignment]
+    obj = prune_nones(obj)
+    data = json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    h = hashlib.new(algo)
+    h.update(data)
+    return f"{algo}:{h.hexdigest()}"
+
+
+def approx_equal(a: float, b: float, eps: float = 1e-9) -> bool:
+    return abs(a - b) <= eps

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyyaml
 pytest
 flake8
 jupyter
+jsonschema

--- a/scripts/io_cli.py
+++ b/scripts/io_cli.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from common.io_loader import (
+    AllocationItem,
+    PortfolioAllocation,
+    Signal,
+    StrategyReturn,
+    TradeEvent,
+    read_allocation_json,
+    read_signals_ndjson,
+    read_strategy_returns_ndjson,
+    read_trade_events_ndjson,
+    write_allocation_json,
+    write_signals_ndjson,
+    write_strategy_returns_ndjson,
+    write_trade_events_ndjson,
+)
+
+
+def cmd_validate(args: argparse.Namespace) -> None:
+    if args.kind == "signals":
+        read_signals_ndjson(args.path)
+    elif args.kind == "events":
+        read_trade_events_ndjson(args.path)
+    elif args.kind == "returns":
+        read_strategy_returns_ndjson(args.path)
+    elif args.kind == "alloc":
+        read_allocation_json(args.path)
+    print("✅ valid:", args.path)
+
+
+def cmd_summarize(args: argparse.Namespace) -> None:
+    if args.kind == "returns":
+        rows = read_strategy_returns_ndjson(args.path)
+        pnl = [row.pnl for row in rows]
+        equity = [row.equity for row in rows]
+        print(
+            "n={n}  pnl_sum={pnl_sum:.2f}  pnl_mean={pnl_mean:.2f}  eq_last={eq_last}".format(
+                n=len(rows),
+                pnl_sum=sum(pnl) if pnl else 0.0,
+                pnl_mean=statistics.mean(pnl) if pnl else 0.0,
+                eq_last=equity[-1] if equity else "—",
+            )
+        )
+    elif args.kind == "events":
+        rows = read_trade_events_ndjson(args.path)
+        by_event: dict[str, int] = {}
+        for row in rows:
+            by_event[row.event] = by_event.get(row.event, 0) + 1
+        print("counts:", json.dumps(by_event, indent=2))
+    else:
+        print(f"No summary implemented for {args.kind}", file=sys.stderr)
+
+
+def cmd_convert(args: argparse.Namespace) -> None:
+    if args.kind == "alloc":
+        rows = read_strategy_returns_ndjson(args.path)
+        weights: dict[tuple[str, str], float] = {}
+        for row in rows:
+            key = (row.strategy, row.symbol)
+            sharpe = row.sharpe if row.sharpe is not None and row.sharpe > 0 else 1.0
+            weights[key] = weights.get(key, 0.0) + sharpe
+        total = sum(weights.values()) or 1.0
+        allocations = [
+            AllocationItem(strategy=strategy, symbol=symbol, weight=value / total)
+            for (strategy, symbol), value in weights.items()
+        ]
+        allocation = PortfolioAllocation(
+            id=args.alloc_id, timestamp=args.timestamp, allocations=allocations
+        )
+        write_allocation_json(args.out, allocation, add_hash=True)
+        print("Wrote allocation:", args.out)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    validate = sub.add_parser("validate")
+    validate.add_argument("--kind", choices=["signals", "events", "returns", "alloc"], required=True)
+    validate.add_argument("--path", required=True)
+    validate.set_defaults(func=cmd_validate)
+
+    summarize = sub.add_parser("summarize")
+    summarize.add_argument("--kind", choices=["events", "returns"], required=True)
+    summarize.add_argument("--path", required=True)
+    summarize.set_defaults(func=cmd_summarize)
+
+    convert = sub.add_parser("convert")
+    convert.add_argument("--kind", choices=["alloc"], required=True)
+    convert.add_argument("--path", required=True, help="strategy_returns.ndjson")
+    convert.add_argument("--alloc-id", required=True)
+    convert.add_argument("--timestamp", required=True)
+    convert.add_argument("--out", required=True)
+    convert.set_defaults(func=cmd_convert)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_io_cli.py
+++ b/tests/test_io_cli.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, "scripts/io_cli.py", *args], check=False, text=True)
+
+
+def test_cli_validate_samples() -> None:
+    assert run_cli("validate", "--kind", "signals", "--path", "samples/brain_signals.ndjson").returncode == 0
+    assert run_cli("validate", "--kind", "events", "--path", "samples/trade_events.ndjson").returncode == 0
+    assert run_cli("validate", "--kind", "returns", "--path", "samples/strategy_returns.ndjson").returncode == 0
+    assert run_cli("validate", "--kind", "alloc", "--path", "samples/portfolio_allocation.json").returncode == 0

--- a/tests/test_io_loader.py
+++ b/tests/test_io_loader.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from common.io_loader import (
+    AllocationItem,
+    PortfolioAllocation,
+    Signal,
+    StrategyReturn,
+    TradeEvent,
+    read_allocation_json,
+    read_signals_ndjson,
+    read_strategy_returns_ndjson,
+    read_trade_events_ndjson,
+    write_allocation_json,
+    write_signals_ndjson,
+    write_strategy_returns_ndjson,
+    write_trade_events_ndjson,
+)
+
+
+def test_signal_roundtrip(tmp_path: Path) -> None:
+    signal = Signal(
+        id="sig1",
+        timestamp="2025-09-25T00:00:00Z",
+        symbol="NQ",
+        side="LONG",
+        confidence=0.8,
+        entropy_score=0.3,
+        regime_state="trend_up",
+    ).with_hash()
+    path = tmp_path / "signals.ndjson"
+    write_signals_ndjson(path, [signal])
+    rows = read_signals_ndjson(path)
+    assert rows[0].id == "sig1"
+    assert rows[0].hash and rows[0].hash.startswith("sha256:")
+
+
+def test_allocation_sum(tmp_path: Path) -> None:
+    allocation = PortfolioAllocation(
+        id="alloc1",
+        timestamp="2025-09-25T00:00:00Z",
+        allocations=[
+            AllocationItem(strategy="A", symbol="CL", weight=0.6),
+            AllocationItem(strategy="B", symbol="NQ", weight=0.4),
+        ],
+    ).with_hash()
+    path = tmp_path / "alloc.json"
+    write_allocation_json(path, allocation)
+    loaded = read_allocation_json(path)
+    assert loaded.hash and loaded.hash.startswith("sha256:")
+
+
+def test_events_returns(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.ndjson"
+    returns_path = tmp_path / "returns.ndjson"
+
+    event = TradeEvent(
+        id="e1",
+        timestamp="2025-09-25T00:00:01Z",
+        symbol="CL",
+        event="ENTER",
+        side="LONG",
+        qty=1,
+        price=80.1,
+    )
+    write_trade_events_ndjson(events_path, [event])
+    assert len(read_trade_events_ndjson(events_path)) == 1
+
+    strategy_return = StrategyReturn(
+        id="r1",
+        timestamp="2025-09-25T00:30:00Z",
+        strategy="Sigma",
+        symbol="CL",
+        pnl=50.0,
+        equity=100050.0,
+    )
+    write_strategy_returns_ndjson(returns_path, [strategy_return])
+    loaded_returns = read_strategy_returns_ndjson(returns_path)
+    assert loaded_returns[0].strategy == "Sigma"


### PR DESCRIPTION
## Summary
- add reusable NDJSON/json helpers, canonical hashing, and none-pruning utilities
- introduce schema-backed dataclasses with read/write helpers plus pandas adapters and CLI tooling
- extend test suite and CI workflow to cover new IO utilities and add convenient Make targets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d5e0a6f1e48320a5627484a35076be