### PR TITLE
Add daily ROI metrics export for oracle backtests

### DIFF
--- a/config/strategy.yaml
+++ b/config/strategy.yaml
@@ -60,3 +60,7 @@ exits:
   entropy_fail_safe: 0.65
   flip_on_regime_change: true
   partial_pct: 0.25
+metrics:
+  initial_cash: 100000
+  export_csv: true
+  output_path: artifacts/AethelredsAegis_metrics.csv

--- a/tests/test_io_cli.py
+++ b/tests/test_io_cli.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import subprocess
 import sys
+
+
 def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run([sys.executable, "scripts/io_cli.py", *args], check=False, text=True)
 

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -1,4 +1,7 @@
+from pathlib import Path
+
 import pandas as pd
+import yaml
 
 from src.exchange import PaperExchange
 from src.mnemonic_capsule import MnemonicCapsule
@@ -41,3 +44,24 @@ def test_oracle_ritualizes_and_returns_capsule(tmp_path):
         writer = MnemonicCapsule(str(path), enabled=True)
         writer.save(capsule)
         assert path.exists()
+
+
+def test_backtest_exports_daily_roi(tmp_path):
+    base_config = yaml.safe_load(Path("config/strategy.yaml").read_text())
+    metrics_path = tmp_path / "metrics.csv"
+    base_config["metrics"] = {
+        "initial_cash": 50_000,
+        "export_csv": True,
+        "output_path": str(metrics_path),
+    }
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(base_config))
+    oracle = TradeOracle(str(config_path), exchange=PaperExchange(seed=11), capsule_enabled=False)
+    frame = synthetic_frame()
+    oracle.backtest(frame, symbol="BTC/USDT")
+    assert metrics_path.exists()
+    lines = [line for line in metrics_path.read_text().splitlines() if line]
+    assert lines[0] == "date,sod_equity,eod_equity,day_pnl,day_roi"
+    assert len(lines) >= 2  # header + at least one trading day entry
+    adr = oracle.performance.average_daily_return()
+    assert isinstance(adr, float)


### PR DESCRIPTION
## Summary
- extend the oracle performance tracker to derive daily PnL/ROI, roll equity, and optionally export metrics to CSV
- expose metrics configuration (initial cash, export flag, output path) via strategy config and reset metrics at the start of each backtest
- add regression coverage ensuring backtests emit the CSV and update the CLI test formatting to satisfy style checks

## Testing
- pytest
- flake8 src tests

------
https://chatgpt.com/codex/tasks/task_e_68d5f1180a5883209e4d55e167eaf93a